### PR TITLE
why is eslint breaking builds (is it eslint?)

### DIFF
--- a/src/components/solid/StratHero/StratHero.tsx
+++ b/src/components/solid/StratHero/StratHero.tsx
@@ -1,13 +1,6 @@
 /** @jsxImportSource solid-js */
 
-import {
-    type ComponentProps,
-    For,
-    createSignal,
-    createMemo,
-    Show,
-} from "solid-js";
-
+import { type ComponentProps, For, createSignal, createMemo } from "solid-js";
 import * as GT from "./GameTypes";
 import { ArrowWidget } from "./Components/ArrowWidget";
 import { CurrentStratView } from "./Components/CurrentStratView";


### PR DESCRIPTION
An error that doesn't come from a compiler is really a warning and warning are meant to be ignored otherwise they'd be errors.